### PR TITLE
Fix setuptools.setup kwarg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     # package installation
     package_dir = {'':'src'},
     packages = ['colormap'],
-    requires = install_requires,
+    install_requires = install_requires,
 )
 
 


### PR DESCRIPTION
`requires` isn't a kwarg for `setuptools.setup`, `install_requires` is.

https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#setup-args

There could be some further cleanup to the installation requirements to
be more consistent. `setup.py` is compiling its own list instead of using
`requirements.txt`. I'd probably remove `requirements.txt` altogether, but
this is a direct resolution to the import failure that occurs if the
requirements aren't installed separately from the package itself.

Before this change, when the package is installed from pip with or without wheel installed:

## Failing import before change
```
❯ python3.8 -m venv .venv
❯ source .venv/bin/activate
❯ pip install colormap
Collecting colormap
  Using cached colormap-1.0.4-py3-none-any.whl
Installing collected packages: colormap
Successfully installed colormap-1.0.4
WARNING: You are using pip version 21.0.1; however, version 22.0.4 is available.
You should consider upgrading via the '/home/mshriver/repos/colormap/.venv/bin/python3.8 -m pip install --upgrade pip' command.
❯ pip freeze
colormap==1.0.4
❯ python -c 'from colormap import Colormap'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/mshriver/repos/colormap/.venv/lib64/python3.8/site-packages/colormap/__init__.py", line 31, in <module>
    from . import colors
  File "/home/mshriver/repos/colormap/.venv/lib64/python3.8/site-packages/colormap/colors.py", line 26, in <module>
    from easydev.tools import check_param_in_list, swapdict, check_range
ModuleNotFoundError: No module named 'easydev'

```


## Example of requirement installation
```
❯ python3.8 -m venv .venv
❯ source .venv/bin/activate
❯ pip install -e .
Obtaining file:///home/mshriver/repos/colormap
Installing collected packages: colormap
  Running setup.py develop for colormap
Successfully installed colormap
WARNING: You are using pip version 21.0.1; however, version 22.0.4 is available.
You should consider upgrading via the '/home/mshriver/repos/colormap/.venv/bin/python3.8 -m pip install --upgrade pip' command.
❯ pip install wheel
Collecting wheel
  Using cached wheel-0.37.1-py2.py3-none-any.whl (35 kB)
Installing collected packages: wheel
Successfully installed wheel-0.37.1
WARNING: You are using pip version 21.0.1; however, version 22.0.4 is available.
You should consider upgrading via the '/home/mshriver/repos/colormap/.venv/bin/python3.8 -m pip install --upgrade pip' command.
❯ pip install -e .
Obtaining file:///home/mshriver/repos/colormap
Installing collected packages: colormap
  Attempting uninstall: colormap
    Found existing installation: colormap 1.0.4
    Uninstalling colormap-1.0.4:
      Successfully uninstalled colormap-1.0.4
  Running setup.py develop for colormap
Successfully installed colormap
WARNING: You are using pip version 21.0.1; however, version 22.0.4 is available.
You should consider upgrading via the '/home/mshriver/repos/colormap/.venv/bin/python3.8 -m pip install --upgrade pip' command.
❯ pip freeze
-e git+git@github.com:mshriver/colormap.git@f9f5b066d8c057958f2af37bd2b64f67b8290b56#egg=colormap
❯ vim setup.py
❯ git diff
diff --git a/setup.py b/setup.py
index f4b5475..a64064d 100644
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     # package installation
     package_dir = {'':'src'},
     packages = ['colormap'],
-    requires = install_requires,
+    install_requires = install_requires,
 )
 
 
❯ pip install -e .
Obtaining file:///home/mshriver/repos/colormap
Collecting matplotlib
  Downloading matplotlib-3.5.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl (11.3 MB)
     |████████████████████████████████| 11.3 MB 8.5 MB/s 
Collecting easydev
  Downloading easydev-0.12.0.tar.gz (47 kB)
     |████████████████████████████████| 47 kB 6.3 MB/s 
Collecting colorama
  Using cached colorama-0.4.4-py2.py3-none-any.whl (16 kB)
Collecting pexpect
  Using cached pexpect-4.8.0-py2.py3-none-any.whl (59 kB)
Collecting colorlog
  Downloading colorlog-6.6.0-py2.py3-none-any.whl (11 kB)
Collecting pillow>=6.2.0
  Downloading Pillow-9.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.3 MB)
     |████████████████████████████████| 4.3 MB 8.9 MB/s 
Collecting cycler>=0.10
  Downloading cycler-0.11.0-py3-none-any.whl (6.4 kB)
Collecting numpy>=1.17
  Downloading numpy-1.22.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.8 MB)
     |████████████████████████████████| 16.8 MB 8.7 MB/s 
Collecting packaging>=20.0
  Using cached packaging-21.3-py3-none-any.whl (40 kB)
Collecting python-dateutil>=2.7
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting pyparsing>=2.2.1
  Using cached pyparsing-3.0.7-py3-none-any.whl (98 kB)
Collecting fonttools>=4.22.0
  Downloading fonttools-4.31.2-py3-none-any.whl (899 kB)
     |████████████████████████████████| 899 kB 10.1 MB/s 
Collecting kiwisolver>=1.0.1
  Downloading kiwisolver-1.4.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl (1.2 MB)
     |████████████████████████████████| 1.2 MB 11.9 MB/s 
Collecting six>=1.5
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting ptyprocess>=0.5
  Using cached ptyprocess-0.7.0-py2.py3-none-any.whl (13 kB)
Building wheels for collected packages: easydev
  Building wheel for easydev (setup.py) ... done
  Created wheel for easydev: filename=easydev-0.12.0-py3-none-any.whl size=64232 sha256=a04e09776b0390d9e3d1cbec0fcfde15619a1d9b447be2aa1e1c3ef48f8e37e7
  Stored in directory: /home/mshriver/.cache/pip/wheels/e2/47/9f/de01f291cfde341b33383bcf1292b17d64c700d4a12b318a7d
Successfully built easydev
Installing collected packages: six, pyparsing, ptyprocess, python-dateutil, pillow, pexpect, packaging, numpy, kiwisolver, fonttools, cycler, colorlog, colorama, matplotlib, easydev, colormap
  Attempting uninstall: colormap
    Found existing installation: colormap 1.0.4
    Uninstalling colormap-1.0.4:
      Successfully uninstalled colormap-1.0.4
  Running setup.py develop for colormap
Successfully installed colorama-0.4.4 colorlog-6.6.0 colormap cycler-0.11.0 easydev-0.12.0 fonttools-4.31.2 kiwisolver-1.4.2 matplotlib-3.5.1 numpy-1.22.3 packaging-21.3 pexpect-4.8.0 pillow-9.0.1 ptyprocess-0.7.0 pyparsing-3.0.7 python-dateutil-2.8.2 six-1.16.0

❯ python -c 'from colormap import Colormap'
❯ echo $?
0


```

This isn't caught by the github workflows because they install from requirements.txt directly or don't use the package after installing. 